### PR TITLE
Add soft PWM methods

### DIFF
--- a/lib/wiringpi/gpio.rb
+++ b/lib/wiringpi/gpio.rb
@@ -97,6 +97,14 @@ module WiringPi
 	  return Wiringpi2.pwmSetClock(divisor)
 	end
 
+  def soft_pwm_create(pin, initial_value, pwm_range)
+    return Wiringpi2.softPwmCreate(pin, initial_value, pwm_range)
+  end
+
+  def soft_pwm_write(pin, value)
+    Wiringpi2.softPwmWrite(pin, value)
+  end
+
 	def gpio_clock_set(pin, freq)
 	  return Wiringpi2.gpioClockSet(pin, freq)
 	end


### PR DESCRIPTION
Add the softPwmCreate() and the softPwmWrite() methods supported by WiringPi.

If you pull this, can you also release a new version of the gem too please?
