### PR TITLE
Run Wiringpi-Ruby on the latest RPi and Raspbian Stretch

### DIFF
--- a/ext/wiringpi/extconf.rb
+++ b/ext/wiringpi/extconf.rb
@@ -2,6 +2,7 @@ require 'mkmf'
 
 LIBDIR      = RbConfig::CONFIG['libdir']
 INCLUDEDIR  = RbConfig::CONFIG['includedir']
+$LIBRUBYARG_SHARED += " -lrt"
 
 $srcs = Dir.glob('WiringPi/wiringPi/*.c')
 $srcs += Dir.glob('WiringPi/devLib/*.c')

--- a/wiringpi.gemspec
+++ b/wiringpi.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name	= 'wiringpi'
-  s.version	= '2.32.0'
-  s.license = 'GNU Lesser General Public License v3'
+  s.version	= '2.46.0'
+  s.license = 'LGPL-3.0'
   s.date	= '2013-04-07'
   s.platform= Gem::Platform::RUBY
   s.summary	= "Arduino wiring-like library for Raspberry Pi GPIO. Will only work on a Pi. Alpha version."


### PR DESCRIPTION
I'll send patch to run wiringpi-ruby on the latest RPi and Raspbian Stretch.
However, I have only tested the sample script written in README.md.

* Bump wiringpi version to 2.46.
* Fix extconf.rb for compiling with raspbian stretch. add -lrt option.